### PR TITLE
Add JMH collections benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Store Search Performance Tester
+
+This project provides microbenchmarks for common Java collections using JMH.
+It measures insertion and lookup performance for `HashMap`, `TreeMap`, and
+`ArrayList`.
+
+## Running Benchmarks
+
+Make sure Maven is installed, then build the shaded JAR and run it:
+
+```bash
+mvn package
+java -jar target/store-search-performance-tester-1.0-SNAPSHOT.jar
+```
+
+JMH will execute the benchmarks and report the results.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,58 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>store-search-performance-tester</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Store Search Performance Tester</name>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.37</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.37</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.example.BenchmarkRunner</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/BenchmarkRunner.java
+++ b/src/main/java/com/example/BenchmarkRunner.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+public class BenchmarkRunner {
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(CollectionsBenchmark.class.getSimpleName())
+                .forks(1)
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/src/main/java/com/example/CollectionsBenchmark.java
+++ b/src/main/java/com/example/CollectionsBenchmark.java
@@ -1,0 +1,99 @@
+package com.example;
+
+import java.util.*;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class CollectionsBenchmark {
+
+    @Param({"1000", "10000", "100000"})
+    private int size;
+
+    private int[] data;
+    private Map<Integer, Integer> hashMap;
+    private Map<Integer, Integer> treeMap;
+    private List<Integer> arrayList;
+
+    @Setup(Level.Iteration)
+    public void setup() {
+        data = new int[size];
+        for (int i = 0; i < size; i++) {
+            data[i] = i;
+        }
+        hashMap = new HashMap<>(size);
+        treeMap = new TreeMap<>();
+        arrayList = new ArrayList<>(size);
+        for (int value : data) {
+            hashMap.put(value, value);
+            treeMap.put(value, value);
+            arrayList.add(value);
+        }
+    }
+
+    @Benchmark
+    public Map<Integer, Integer> hashMapInsertion() {
+        Map<Integer, Integer> map = new HashMap<>(size);
+        for (int value : data) {
+            map.put(value, value);
+        }
+        return map;
+    }
+
+    @Benchmark
+    public Map<Integer, Integer> treeMapInsertion() {
+        Map<Integer, Integer> map = new TreeMap<>();
+        for (int value : data) {
+            map.put(value, value);
+        }
+        return map;
+    }
+
+    @Benchmark
+    public List<Integer> arrayListInsertion() {
+        List<Integer> list = new ArrayList<>(size);
+        for (int value : data) {
+            list.add(value);
+        }
+        return list;
+    }
+
+    @Benchmark
+    public int hashMapLookup() {
+        int sum = 0;
+        for (int value : data) {
+            Integer v = hashMap.get(value);
+            if (v != null) {
+                sum += v;
+            }
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int treeMapLookup() {
+        int sum = 0;
+        for (int value : data) {
+            Integer v = treeMap.get(value);
+            if (v != null) {
+                sum += v;
+            }
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int arrayListLookup() {
+        int sum = 0;
+        for (int value : data) {
+            if (arrayList.contains(value)) {
+                sum += value;
+            }
+        }
+        return sum;
+    }
+}
+


### PR DESCRIPTION
## Summary
- set up Maven project with JMH
- add `CollectionsBenchmark` to measure HashMap, TreeMap and ArrayList insertion and lookup
- include a runner class and README instructions

## Testing
- `mvn -Djava.net.preferIPv4Stack=true -q package` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68441cdd286c832db5e6efbfab8876eb