### PR TITLE
Add Elasticsearch benchmarking script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Store Search Performance Tester
+
+This repository provides simple benchmarking utilities for evaluating search backends.
+
+## Elasticsearch Benchmark
+
+`elasticsearch_benchmark.py` allows you to measure full-text search performance of an Elasticsearch cluster.
+
+### Requirements
+
+- Python 3.8+
+- `elasticsearch` Python package (`pip install elasticsearch`)
+- An accessible Elasticsearch server
+
+### Usage
+
+Prepare JSON files for the index mapping, documents to index, and search queries.
+
+```bash
+python3 elasticsearch_benchmark.py \
+  --host http://localhost:9200 \
+  --index test-index \
+  --mapping mapping.json \
+  --documents documents.json \
+  --queries queries.json \
+  --runs 5
+```
+
+The script creates the index (deleting an existing one if present), bulk inserts the provided documents, refreshes the index, and then executes each query multiple times, reporting the average execution time.
+
+You can configure analyzers and mappings in the mapping JSON file to suit your documents.

--- a/elasticsearch_benchmark.py
+++ b/elasticsearch_benchmark.py
@@ -1,0 +1,60 @@
+import argparse
+import json
+import time
+from typing import List, Dict, Any
+
+from elasticsearch import Elasticsearch, helpers
+
+
+def create_index(es: Elasticsearch, index: str, mapping: Dict[str, Any]) -> None:
+    if es.indices.exists(index=index):
+        es.indices.delete(index=index)
+    es.indices.create(index=index, body=mapping)
+
+
+def bulk_insert(es: Elasticsearch, index: str, docs: List[Dict[str, Any]]) -> None:
+    actions = [{"_index": index, "_source": doc} for doc in docs]
+    helpers.bulk(es, actions)
+
+
+def benchmark_search(es: Elasticsearch, index: str, queries: List[Dict[str, Any]], runs: int) -> None:
+    for q in queries:
+        total_time = 0.0
+        for _ in range(runs):
+            start = time.time()
+            es.search(index=index, body=q)
+            total_time += time.time() - start
+        avg = total_time / runs
+        print(f"Query: {json.dumps(q)} took {avg:.4f}s on average over {runs} runs")
+
+
+def load_json(path: str) -> Any:
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Elasticsearch full-text search benchmark")
+    parser.add_argument('--host', default='http://localhost:9200', help='Elasticsearch host URL')
+    parser.add_argument('--index', required=True, help='Index name to use for benchmarking')
+    parser.add_argument('--mapping', required=True, help='Path to JSON mapping file')
+    parser.add_argument('--documents', required=True, help='Path to JSON file with documents to index')
+    parser.add_argument('--queries', required=True, help='Path to JSON file with search queries')
+    parser.add_argument('--runs', type=int, default=5, help='Number of runs per query')
+    args = parser.parse_args()
+
+    es = Elasticsearch(args.host)
+
+    mapping = load_json(args.mapping)
+    docs = load_json(args.documents)
+    queries = load_json(args.queries)
+
+    create_index(es, args.index, mapping)
+    bulk_insert(es, args.index, docs)
+    es.indices.refresh(index=args.index)
+
+    benchmark_search(es, args.index, queries, args.runs)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add an Elasticsearch benchmark utility
- document how to use the tool in a README

## Testing
- `python3 -m py_compile elasticsearch_benchmark.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441cfadeb8832db9db056ccba322b2